### PR TITLE
Implement Send for `Vad`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,8 @@ impl Default for Vad {
     }
 }
 
+unsafe impl Send for Vad {}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
It should be safe to implement `Send` for `Vad` since `Vad` does not contain any `Rc` analogs and other non-sendable types